### PR TITLE
Feature/datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.8](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.7...v0.1.8) (2021-07-30)
+
 ### [0.1.7](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.6...v0.1.7) (2021-07-30)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.7](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.6...v0.1.7) (2021-07-30)
+
+
+### Features
+
+* **datasource:** fetch datasource api ([a68f7e9](https://github.com/qcloud-apaas/web-sdk/commit/a68f7e92fd067e9c66fb531e9c0a5eb631ef293d))
+
 ### [0.1.6](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.5...v0.1.6) (2021-07-30)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.10](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.9...v0.1.10) (2021-08-03)
+
+
+### Features
+
+* **observer:** add useModel api ([cc5a528](https://github.com/qcloud-apaas/web-sdk/commit/cc5a528fa821badca7591e080418493597f5b257))
+
 ### [0.1.9](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.8...v0.1.9) (2021-08-02)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.9](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.8...v0.1.9) (2021-08-02)
+
+
+### Features
+
+* **canvas:** add useCanvas api ([69eba01](https://github.com/qcloud-apaas/web-sdk/commit/69eba018b56f875288bd88ca9979d12e51cf38fe))
+* **observer:** add componentState api ([fbf6b57](https://github.com/qcloud-apaas/web-sdk/commit/fbf6b57d6bf924942a32098f795ddc4e0c4100db))
+
 ### [0.1.8](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.7...v0.1.8) (2021-07-30)
 
 ### [0.1.7](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.6...v0.1.7) (2021-07-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.11](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.10...v0.1.11) (2021-08-03)
+
+
+### Features
+
+* **eventbus:** add useEventBus api ([ad5cea8](https://github.com/qcloud-apaas/web-sdk/commit/ad5cea85294fb3ecf4cd17adc1dd004ff0cac79b))
+
 ### [0.1.10](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.9...v0.1.10) (2021-08-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.12](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.11...v0.1.12) (2021-08-03)
+
 ### [0.1.11](https://github.com/qcloud-apaas/web-sdk/compare/v0.1.10...v0.1.11) (2021-08-03)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qcloud-apaas/web-sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qcloud-apaas/web-sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qcloud-apaas/web-sdk",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qcloud-apaas/web-sdk",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qcloud-apaas/web-sdk",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qcloud-apaas/web-sdk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qcloud-apaas/web-sdk",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "SDK for apaas component deveopment",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qcloud-apaas/web-sdk",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "SDK for apaas component deveopment",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qcloud-apaas/web-sdk",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "SDK for apaas component deveopment",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qcloud-apaas/web-sdk",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "SDK for apaas component deveopment",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qcloud-apaas/web-sdk",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "SDK for apaas component deveopment",
   "license": "MIT",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qcloud-apaas/web-sdk",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "SDK for apaas component deveopment",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/types/canvas.ts
+++ b/src/types/canvas.ts
@@ -1,0 +1,27 @@
+export enum CanvasSize {
+  pc = 'pc',
+  pad = 'pad',
+  mobile = 'mobile',
+}
+
+export enum CanvasMode {
+  design = 'design',
+  run = 'run',
+}
+
+export type CanvasResult = {
+  /**
+   * 当前页面Code
+   */
+  pageCode: string;
+  /**
+   * design 设计态 run 运行态
+   */
+  mode: CanvasMode;
+  /**
+   * 当前画布尺寸
+   */
+  size: CanvasSize;
+};
+
+export type UseCanvasApi = () => CanvasResult;

--- a/src/types/canvas.ts
+++ b/src/types/canvas.ts
@@ -22,6 +22,22 @@ export type CanvasResult = {
    * 当前画布尺寸
    */
   size: CanvasSize;
+  /**
+   * 传入key获取 页面级存储的值
+   */
+  getValue<V = any>(key: string): V;
+  /**
+   * 传入key设置 页面级存储的值
+   */
+  setValue<V = any>(key: string, value: V): void;
+  /**
+   * 传入key获取 上下文中的值
+   */
+  // getContextValue<V = any>(key: string): V;
+  /**
+   * 传入key设置 上下文中的值
+   */
+  // setContextValue<V = any>(key: string, value: V): void;
 };
 
 export type UseCanvasApi = () => CanvasResult;

--- a/src/types/container-context-data.ts
+++ b/src/types/container-context-data.ts
@@ -1,5 +1,6 @@
 import { FormApi } from 'final-form';
 import { FieldRenderProps } from 'react-final-form-hooks';
+import { CanvasMode, CanvasSize } from './canvas';
 
 export type ControlSetting = {
   created?: boolean; // 组件创建控制器，用于控制组件内部创建动作
@@ -145,17 +146,6 @@ export type ListViewRecordContextData = {
   evaluateExpression: (exp: string) => Promise<{ type: EvaluateExpressionResultType; value: any }>;
 };
 
-export enum CanvasSize {
-  pc = 'pc',
-  pad = 'pad',
-  mobile = 'mobile',
-}
-
-export enum CanvasMode {
-  design = 'design',
-  run = 'run',
-}
-
 export type CanvasContextData = {
   /**
    * 画布尺寸
@@ -165,6 +155,15 @@ export type CanvasContextData = {
    * 画布模式，运行态、设计态
    */
   mode: CanvasMode;
+  /**
+   * 当前页面编码
+   */
+  pageCode: string;
+  /**
+   * @deprecated
+   * 当前页面编码
+   */
+  pageKey: string;
   /**
    * 返回整个画布的上下文数据，仅运行态使用
    */

--- a/src/types/eventbus.ts
+++ b/src/types/eventbus.ts
@@ -1,0 +1,11 @@
+type EventBusHandler<T> = (payload: T) => void;
+type EventBusUnsubscribe = () => void;
+
+export declare class CanvasEventBus {
+  on<T = any>(name: string, handler: EventBusHandler<T>): EventBusUnsubscribe;
+  once<T = any>(name: string, handler: EventBusHandler<T>): void;
+  off<T = any>(name: string, handler: EventBusHandler<T>): void;
+  emit<T = any>(name: string, payload: T): void;
+}
+
+export type UseEventBusApi = (namespace: string) => CanvasEventBus;

--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -11,20 +11,42 @@ export type DataSourceCondition = {
   Connector: 'AND' | 'OR';
 };
 
-export type DataSourceParams = {
-  Params: any;
+export type DataSourceRequestParams = {
+  Params?: any;
   Filter: {
-    Condition: DataSourceCondition;
-    Option: {
+    Condition?: DataSourceCondition;
+    Option?: {
       Offset: number;
       Limit: number;
-      OrderBy: {
+      OrderBy?: {
         FieldCode: string;
         Order: 'DESC' | 'ASC';
-        Count: boolean;
       };
+      Count?: boolean;
     };
   };
+};
+
+export type DataSourceRecordItem = {
+  recordId: string;
+  fieldValueMap: Record<string, any>;
+  entityCode?: string;
+  entityApiKey?: string;
+};
+
+export type DataSourceObjectListResponse = {
+  records: DataSourceRecordItem[];
+  total: number;
+};
+
+export type DataSourceJsonSchemaResponse<T = any> = {
+  response: T;
+  matchReponse: any;
+};
+
+export type DataSourceResponse = {
+  databaseResponse: DataSourceObjectListResponse;
+  flowResponse: (DataSourceObjectListResponse & DataSourceJsonSchemaResponse)[];
 };
 
 /**
@@ -55,4 +77,7 @@ export type DeleteRecordsMethod = (data: MetaDataApiParams & { recordIds: string
  */
 export type FetchRecordsByConditionMethod = (data: MetaDataApiParams) => Promise<Record<string, any>>;
 
-export type FetchByDataSourceMethod = <T = any>(dataSource: DynamicDataSource, params?: DataSourceParams) => Promise<T>;
+export type FetchByDataSourceMethod = <T = any>(
+  dataSource: DynamicDataSource,
+  params?: DataSourceRequestParams,
+) => Promise<T>;

--- a/src/types/fetch.ts
+++ b/src/types/fetch.ts
@@ -1,4 +1,4 @@
-import { DynamicDataSource } from './properties';
+import { DynamicDataSource, ObjectVariableType } from './properties';
 
 export type MetaDataApiParams = {
   appCode: string;
@@ -35,6 +35,7 @@ export type DataSourceRecordItem = {
 };
 
 export type DataSourceObjectListResponse = {
+  variableType?: ObjectVariableType;
   records: DataSourceRecordItem[];
   total: number;
 };
@@ -77,7 +78,7 @@ export type DeleteRecordsMethod = (data: MetaDataApiParams & { recordIds: string
  */
 export type FetchRecordsByConditionMethod = (data: MetaDataApiParams) => Promise<Record<string, any>>;
 
-export type FetchByDataSourceMethod = <T = any>(
+export type FetchByDataSourceMethod = <T = DataSourceResponse>(
   dataSource: DynamicDataSource,
   params?: DataSourceRequestParams,
 ) => Promise<T>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,7 @@ export * from './panel-config';
 export * from './trans';
 export * from './use-event-handlers';
 export * from './model';
+export * from './properties';
 
 export { DesignModeBuiltIns, RunModeBuiltIns };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,7 @@ import { DesignModeBuiltIns, RunModeBuiltIns } from './builtins';
 import { UseDataSourceApi } from './properties';
 import { UseCanvasApi } from './canvas';
 import { UseComponentStateApi, UseComponentSubscriberApi, UseModelApi } from './observer';
+import { UseEventBusApi } from './eventbus';
 
 export * from './component-key';
 export * from './container-context-data';
@@ -81,6 +82,7 @@ export type RunModeSDKInjection = {
   useComponentState: UseComponentStateApi;
   useComponentSubscriber: UseComponentSubscriberApi;
   useModel: UseModelApi;
+  useEventBus: UseEventBusApi;
 };
 
 export type RunModeSDK = CommonSDK & RunModeSDKInjection;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,7 +24,7 @@ import { UseEventHandlers } from './use-event-handlers';
 import { DesignModeBuiltIns, RunModeBuiltIns } from './builtins';
 import { UseDataSourceApi } from './properties';
 import { UseCanvasApi } from './canvas';
-import { UseComponentStateApi, UseComponentSubscriberApi } from './observer';
+import { UseComponentStateApi, UseComponentSubscriberApi, UseModelApi } from './observer';
 
 export * from './component-key';
 export * from './container-context-data';
@@ -80,6 +80,7 @@ export type RunModeSDKInjection = {
   fetchByDataSource: FetchByDataSourceMethod;
   useComponentState: UseComponentStateApi;
   useComponentSubscriber: UseComponentSubscriberApi;
+  useModel: UseModelApi;
 };
 
 export type RunModeSDK = CommonSDK & RunModeSDKInjection;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,8 @@ import {
 import { UseEventHandlers } from './use-event-handlers';
 import { DesignModeBuiltIns, RunModeBuiltIns } from './builtins';
 import { UseDataSourceApi } from './properties';
+import { UseCanvasApi } from './canvas';
+import { UseComponentStateApi, UseComponentSubscriberApi } from './observer';
 
 export * from './component-key';
 export * from './container-context-data';
@@ -34,6 +36,8 @@ export * from './trans';
 export * from './use-event-handlers';
 export * from './model';
 export * from './properties';
+export * from './canvas';
+export * from './observer';
 
 export { DesignModeBuiltIns, RunModeBuiltIns };
 
@@ -54,6 +58,7 @@ export type CommonSDK = {
   transMetaVal2PureVal: typeof transMetaVal2PureVal;
   transObjectKeys: typeof transObjectKeys;
   useDynamicValue: typeof useDynamicValue;
+  useCanvas: UseCanvasApi;
 };
 
 export type DesignModeSDKInjection = {
@@ -73,6 +78,8 @@ export type RunModeSDKInjection = {
   modifyRecordAttribute: ModifyRecordAttributeMethod;
   fetchRecordsByCondition: FetchRecordsByConditionMethod;
   fetchByDataSource: FetchByDataSourceMethod;
+  useComponentState: UseComponentStateApi;
+  useComponentSubscriber: UseComponentSubscriberApi;
 };
 
 export type RunModeSDK = CommonSDK & RunModeSDKInjection;

--- a/src/types/observer.ts
+++ b/src/types/observer.ts
@@ -24,15 +24,10 @@ declare function UseComponentSubscriberApi<V>(callback: UseComponentSubscriberCa
 export type UseComponentStateApi = typeof UseComponentState;
 export type UseComponentSubscriberApi = typeof UseComponentSubscriber;
 
-export type UseModelApi<V = any, M = any> = (
+export type UseModelApi<V = any> = (
   componentKey: string,
-  initial?: {
-    value: V;
-    meta: M;
-  },
+  initialValue?: V,
 ) => {
   value: V;
   onChange: (val: V) => void;
-  meta: M;
-  onMetaChange: (meta: M) => void;
 };

--- a/src/types/observer.ts
+++ b/src/types/observer.ts
@@ -23,3 +23,16 @@ declare function UseComponentSubscriberApi<V>(callback: UseComponentSubscriberCa
 
 export type UseComponentStateApi = typeof UseComponentState;
 export type UseComponentSubscriberApi = typeof UseComponentSubscriber;
+
+export type UseModelApi<V = any, M = any> = (
+  componentKey: string,
+  initial?: {
+    value: V;
+    meta: M;
+  },
+) => {
+  value: V;
+  onChange: (val: V) => void;
+  meta: M;
+  onMetaChange: (meta: M) => void;
+};

--- a/src/types/observer.ts
+++ b/src/types/observer.ts
@@ -1,0 +1,25 @@
+export type ComponentState<V = any> = {
+  value: V;
+  visible: boolean;
+  entityCode?: string;
+  recordId?: string;
+  props?: any;
+};
+
+export type SetComponentStateApi<V = any> = (compId: string, state: ComponentState<V>) => void;
+
+export type GetComponentStateApi<V = any> = (compId: string) => ComponentState<V>;
+
+declare function UseComponentState<V = any>(): {
+  getComponentState: GetComponentStateApi<V>;
+  setComponentState: GetComponentStateApi<V>;
+};
+
+type UseComponentSubscriberCallback<V = any> = (compState: ComponentState<V>) => void;
+
+declare function UseComponentSubscriber<V>(compId: string): ComponentState<V>;
+declare function UseComponentSubscriber<V>(compId: string, callback: UseComponentSubscriberCallback): ComponentState<V>;
+declare function UseComponentSubscriberApi<V>(callback: UseComponentSubscriberCallback): ComponentState<V>;
+
+export type UseComponentStateApi = typeof UseComponentState;
+export type UseComponentSubscriberApi = typeof UseComponentSubscriber;

--- a/src/types/panel-config.ts
+++ b/src/types/panel-config.ts
@@ -24,7 +24,8 @@ export type DynamicFormBuildInComps =
   | 'StackLayout'
   | 'PageSetting'
   | 'SortRule'
-  | 'TreeOperatesSetting';
+  | 'TreeOperatesSetting'
+  | 'ComponentSelect';
 
 export type DynamicFormPropType =
   | 'string'
@@ -38,7 +39,8 @@ export type DynamicFormPropType =
   | 'fieldSource'
   | 'defaultValue'
   | 'actionList'
-  | 'dataSource';
+  | 'dataSource'
+  | 'componentSelect';
 
 export type DynamicFormField<V = Record<string, any>> = {
   key: string;
@@ -61,10 +63,12 @@ export type DynamicFormField<V = Record<string, any>> = {
   }[];
   /*
    * @alias useVisible
+   * @deprecated
    */
   dependOn?: (values: any, opt: { hasAncestorComponent: (name: string) => boolean }) => boolean;
   /*
    * @alias useParams
+   * @deprecated
    */
   useParams?: (values: any) => any;
   /*

--- a/src/types/panel-config.ts
+++ b/src/types/panel-config.ts
@@ -17,6 +17,7 @@ export type DynamicFormBuildInComps =
   | 'EventEditor'
   | 'Switch'
   | 'FieldSource'
+  | 'FieldSelect'
   | 'HandleEvent'
   | 'DefaultValue'
   | 'ActionList'
@@ -40,7 +41,7 @@ export type DynamicFormPropType =
   | 'defaultValue'
   | 'actionList'
   | 'dataSource'
-  | 'componentSelect';
+  | 'componentRef';
 
 export type DynamicFormField<V = Record<string, any>> = {
   key: string;

--- a/src/types/properties.ts
+++ b/src/types/properties.ts
@@ -8,7 +8,7 @@ export interface DynamicDataSource {
   flowEntityCode: string;
   sysField: boolean;
   type: 'flow' | 'context' | 'database';
-  variableType: 'object' | 'objectList' | 'jsonSchema';
+  variableType: ObjectVariableType;
   fields: Field[];
 }
 
@@ -20,3 +20,5 @@ export type DesignDataSourceResult = {
 };
 
 export type UseDataSourceApi = (dataSource: DynamicDataSource) => DesignDataSourceResult;
+
+export type ObjectVariableType = 'object' | 'objectList' | 'jsonSchema';

--- a/src/types/properties.ts
+++ b/src/types/properties.ts
@@ -9,13 +9,14 @@ export interface DynamicDataSource {
   sysField: boolean;
   type: 'flow' | 'context' | 'database';
   variableType: 'object' | 'objectList' | 'jsonSchema';
+  fields: Field[];
 }
 
-export type DataSourceResult = {
+export type DesignDataSourceResult = {
   entities: Entity[];
   fields: Field[];
   selectedEntity: Entity;
   selectedEntityCode: string;
 };
 
-export type UseDataSourceApi = (dataSource: DynamicDataSource) => DataSourceResult;
+export type UseDataSourceApi = (dataSource: DynamicDataSource) => DesignDataSourceResult;


### PR DESCRIPTION
## Features

- feat(datasource): fetch datasource api
- feat(observer): add componentState api
- feat(canvas): add useCanvas api
- feat(observer): add useModel api

## api

### useDataSource

Resolves DataSource Prop in design mode and returns with fields and entities.

### fetchByDataSource

Accepts a DataSource prop,  request server by DataSource Params and  responds with `Records`, `TotalCount` and `JsonSchema` result.

### useCanvas

Called `useContext` into CanvasContext, returns with pageCode, size, mode.

### useComponentState

Returns a `getComponentState` and a `setComponentState` function, which could set and get global redux state.

### useModel

A encapsulation api to `useComponentState`.returns `value` and `onChange` that call setter and getter internally.

